### PR TITLE
Publish apps from admin

### DIFF
--- a/django/api/admin.py
+++ b/django/api/admin.py
@@ -39,7 +39,7 @@ class ApplicationAdmin(admin.ModelAdmin):
     def publish(self, obj):
         instance = obj.applicationinstance_set.first()
         html = format_html('<a class="button" href="{}"> Publish </a>'.format(""))
-        return html
+        return html if not instance.is_public else ""
 
 # Register your models here.
 admin.site.register(Board, names(('internal_name',)))

--- a/django/api/admin.py
+++ b/django/api/admin.py
@@ -16,15 +16,34 @@ from api.models import Module
 from api.models import Transaction
 from api.models import UserProfile
 from api.models import Feedback
+from django.utils.html import format_html
+from rest_framework.reverse import reverse
 
 def names(t):
     class AdminClass(admin.ModelAdmin):
         list_display=t
     return AdminClass
 
+class ApplicationAdmin(admin.ModelAdmin):
+    list_display = (
+        'name',
+        'description',
+        'download', 
+        'publish'
+    )
+
+    def download(self, obj):
+        instance = obj.applicationinstance_set.first()
+        return format_html('<a class="button" href="{}"> Download </a>'.format(reverse('application-download', args=[obj.pk])))
+
+    def publish(self, obj):
+        instance = obj.applicationinstance_set.first()
+        html = format_html('<a class="button" href="{}"> Publish </a>'.format(""))
+        return html
+
 # Register your models here.
 admin.site.register(Board, names(('internal_name',)))
-admin.site.register(Application, names(('name', 'description')))
+admin.site.register(Application, ApplicationAdmin)
 admin.site.register(ApplicationInstance, names(('application', 'is_public')))
 admin.site.register(Module, names(('name', 'description')))
 admin.site.register(Transaction, names(('uuid',)))

--- a/django/api/admin.py
+++ b/django/api/admin.py
@@ -24,22 +24,35 @@ def names(t):
         list_display=t
     return AdminClass
 
+def make_approved(modeladmin, request, queryset):
+    for q in queryset:
+        q.applicationinstance_set.update(is_public=True)
+
+def make_unpublish(modeladmin, request, queryset):
+    for q in queryset:
+        q.applicationinstance_set.update(is_public=False)
+
+make_approved.short_description = "Approve selected apps"
+make_unpublish.short_description = "Unpublish selected apps"
+
 class ApplicationAdmin(admin.ModelAdmin):
     list_display = (
         'name',
         'description',
-        'download', 
-        'publish'
+        'download',
+        'approve'
     )
+    actions = [make_approved, make_unpublish]
 
     def download(self, obj):
         instance = obj.applicationinstance_set.first()
         return format_html('<a class="button" href="{}"> Download </a>'.format(reverse('application-download', args=[obj.pk])))
 
-    def publish(self, obj):
+    def approve(self, obj):
         instance = obj.applicationinstance_set.first()
-        html = format_html('<a class="button" href="{}"> Publish </a>'.format(""))
-        return html if not instance.is_public else ""
+        return instance.is_public
+
+    approve.boolean=True
 
 # Register your models here.
 admin.site.register(Board, names(('internal_name',)))

--- a/django/api/serializers.py
+++ b/django/api/serializers.py
@@ -72,7 +72,7 @@ class BoardSerializer(serializers.ModelSerializer):
 
 class CreateUserSerializer(serializers.ModelSerializer):
 
-    is_active = serializers.HiddenField(default=serializers.CreateOnlyDefault(False))
+    is_active = serializers.HiddenField(default=serializers.CreateOnlyDefault(True))
 
     class Meta:
         model = User

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -111,8 +111,9 @@ class ApplicationViewSet(viewsets.ModelViewSet):
     @detail_route(methods=['GET'], permission_classes=[IsAdminUser, ])
     def download(self, request, pk=None):
         app = get_object_or_404(Application, pk=pk)
-        response = HttpResponse(app.app_tarball, content_type='application/force-download')
-        response['Content-Disposition'] = 'attachment; filename=%s' % app.app_tarball.name
+        f = app.applicationinstance_set.first().app_tarball
+        response = HttpResponse(f, content_type='application/force-download')
+        response['Content-Disposition'] = 'attachment; filename=%s.tar.gz' % app.name
 
         return response
 

--- a/django/riot_apps/urls.py
+++ b/django/riot_apps/urls.py
@@ -38,7 +38,7 @@ from rest_framework.authtoken import views
 from riot_apps import settings
 
 router = routers.DefaultRouter()
-router.register(r'app', ApplicationViewSet)
+router.register(r'app', ApplicationViewSet, base_name='application')
 router.register(r'board', BoardViewSet)
 router.register(r'user', UserViewSet, base_name='user')
 router.register(r'feedback', FeedbackViewSet)

--- a/rapstore-frontend/src/app/signup/signup.component.ts
+++ b/rapstore-frontend/src/app/signup/signup.component.ts
@@ -20,7 +20,7 @@ export class SignupComponent implements OnInit {
     this.refresh();
     this.userService.register(this.model)
       .subscribe(result => {
-        this.message = "Successful registration. Please wait until a RAPstore admin activates your account";
+        this.message = "Successful registration!";
         }, err => {
           let errors = JSON.parse(err.text());
           for(let k in errors) {


### PR DESCRIPTION
This PR:
- Enables custom action for approve/unpublish apps from Django Admin
- Sets is_active to True, so new users can't login straight.