### PR TITLE
Dockerfile: remove RIOT clone from builder

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get -y install software-properties-common
 RUN add-apt-repository -uy ppa:team-gcc-arm-embedded/ppa
 RUN apt-get -y install gcc-arm-embedded
 RUN apt-get -y install gcc-msp430
-RUN git clone https://github.com/RIOT-OS/RIOT.git
 
 RUN mkdir /code
 COPY . /code/

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM python:3.5
 ENV PYTHONUNBUFFERED 1
+RUN apt-get update
+RUN apt-get install -y cron
+ADD crontab /etc/cron.d/fetch_riot
+RUN chmod 0644 /etc/cron.d/fetch_riot
 RUN mkdir /code
 RUN mkdir /apps
 COPY . /code/

--- a/django/api/management/commands/populate_db.py
+++ b/django/api/management/commands/populate_db.py
@@ -13,6 +13,7 @@ import sys
 import requests
 import tarfile
 import tempfile
+import io
 
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
@@ -24,6 +25,8 @@ from rest_framework.authtoken.models import Token
 CUR_DIR = os.path.abspath(os.path.dirname(__file__))
 PROJECT_ROOT_DIR = os.path.normpath(os.path.join(CUR_DIR, os.pardir, os.pardir, os.pardir))
 sys.path.append(PROJECT_ROOT_DIR)
+
+CRON_ENCODING="utf-8"
 
 import api.settings as config
 from api.models import Transaction
@@ -141,7 +144,7 @@ def register_riot_apps():
                     'initial_instance.version_name': '1.3.1',
                     'initial_instance.version_code': '7'
                 }
-                files = {'app_tarball': open(tmp_file_path, 'rb')}
+                files = {'app_tarball': io.open(tmp_file_path, 'rb')}
 
                 r = requests.post('http://localhost:8000/api/app/', headers=headers, data=payload, files=files)
 
@@ -196,7 +199,7 @@ def get_description(path, name):
         description = ''
 
         try:
-            with open(path) as file:
+            with io.open(path, 'r', encoding=CRON_ENCODING) as file:
 
                 brief_active = False
                 for line in file:
@@ -255,7 +258,7 @@ def get_name(path, application_directory):
     name = ''
 
     try:
-        with open(os.path.join(path, 'Makefile')) as makefile:
+        with io.open(os.path.join(path, 'Makefile'), 'r', encoding=CRON_ENCODING) as makefile:
             for line in makefile:
 
                 line = line.replace(' ', '')

--- a/django/crontab
+++ b/django/crontab
@@ -1,2 +1,5 @@
-* * * * * root /usr/local/bin/python /code/manage.py populate_db
+LANG=en_US.UTF-2
+LC_CTYPE=en_US.UTF-8
+
+0 */3 * * * root /usr/local/bin/python /code/manage.py populate_db
 # An empty line is required at the end of this file for a valid cron file.

--- a/django/crontab
+++ b/django/crontab
@@ -1,0 +1,2 @@
+* * * * * root /usr/local/bin/python /code/manage.py populate_db
+# An empty line is required at the end of this file for a valid cron file.

--- a/django/docker-entry.sh
+++ b/django/docker-entry.sh
@@ -10,4 +10,4 @@ echo "Load fixtures"
 python manage.py loaddata fixtures/*.json
 
 echo "Starting server"
-python manage.py runserver 0.0.0.0:8000
+cron && python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
This PR remove the `git clone` comamnd in the builder. The RIOT folder is now a shared volume between web and builder, as seen in rapstore_vm.

It also adds cron support for executing populate_db via cron