### PR TITLE
changed approach for app grid to be more responsive

### DIFF
--- a/rapstore-frontend/src/app/app-browser/app-browser.component.css
+++ b/rapstore-frontend/src/app/app-browser/app-browser.component.css
@@ -1,12 +1,4 @@
-.app-overview-item {
-  -webkit-transition: background 0.5s; /* For Safari 3.1 to 6.0 */
-  transition: background 0.5s;
-}
-.app-overview-item:hover {
-  background: #2a9fd6;
-}
-
-.app-panel .app-name {
+.app-name {
   font-size: 1em;
   margin-bottom: 1em;
 
@@ -18,6 +10,24 @@
 
 #app-info-section {
   margin-top: 2em;
+}
+
+.app-item-container {
+  overflow:hidden;
+  text-align:center;
+}
+
+.app-item {
+  width: 260px;
+  margin: 10px;
+  display:inline-block;
+
+  -webkit-transition: background 0.5s; /* For Safari 3.1 to 6.0 */
+  transition: background 0.5s;
+}
+
+.app-item:hover {
+  background: #2a9fd6;
 }
 
 /* http://www.cssportal.com/css-ribbon-generator/ */

--- a/rapstore-frontend/src/app/app-browser/app-browser.component.html
+++ b/rapstore-frontend/src/app/app-browser/app-browser.component.html
@@ -1,11 +1,11 @@
 <div class="row">
-  <ng-container *ngFor="let application of apps; let i = index">
-    <div class="clearfix visible-sm-block" *ngIf="i % 4 == 0"></div>
-    <div class="clearfix visible-md-block" *ngIf="i % 6 == 0"></div>
-    <div class="col-sm-3 col-md-2">
-      <div>
+  <div class="col-md-12">
+    <div class="app-item-container">
+
+      <ng-container *ngFor="let application of apps">
+
         <a class="a-wrapper-no-decoration" routerLink="/app/{{application.id}}">
-          <div class="panel panel-default app-overview-item">
+          <div class="panel panel-default app-item">
             <div class="panel-body app-panel text-center">
               <p class="app-name">{{application?.name | uppercase}}</p>
 
@@ -31,10 +31,9 @@
 
           </div>
         </a>
-      </div>
+
+      </ng-container>
+
     </div>
-    <!--if forloop.counter|divisibleby:6 and not forloop.last
-    </div><div class="row">
-    endif-->
-  </ng-container>
+  </div>
 </div>

--- a/rapstore-frontend/src/app/app-build/app-build.component.html
+++ b/rapstore-frontend/src/app/app-build/app-build.component.html
@@ -1,4 +1,4 @@
-<div class="container rounded app-panel panel-default panel">
+<div class="container rounded panel-default panel">
   <div class="row">
     <div class="col-sm-1">
       <a class="btn btn-primary download-binary-with-info" routerLink="/app/{{application?.id}}">

--- a/rapstore-frontend/src/app/app-detail/app-detail.component.html
+++ b/rapstore-frontend/src/app/app-detail/app-detail.component.html
@@ -1,4 +1,4 @@
-<div class="container rounded app-panel panel-default panel">
+<div class="container rounded panel-default panel">
   <div class="row">
     <div class="col-sm-1">
       <a class="btn btn-primary download-binary-with-info" routerLink="/">


### PR DESCRIPTION
This PR changes the way how the app grid on the homepage is build. As (unwanted) side effect the last row is not left-justified anymore, instead it's centered. But therefore the items within the grid are not getting smaller than allowed for the letter avatar image.

![untitled](https://user-images.githubusercontent.com/9884864/40123769-457c4a84-5927-11e8-98ca-2444c4a58dae.png)
