### PR TITLE
Add tab logic to template

### DIFF
--- a/rapstore-frontend/src/app/app-routing.module.ts
+++ b/rapstore-frontend/src/app/app-routing.module.ts
@@ -16,7 +16,7 @@ import {AboutComponent} from './about/about.component';
 
 
 const routes: Routes = [
-  {path: '', redirectTo: 'app', pathMatch: 'full'},
+  {path: '', component: AppBrowserComponent},
   {path: 'signup', component: SignupComponent},
   {path: 'login', component: LoginComponent},
 

--- a/rapstore-frontend/src/app/app.component.html
+++ b/rapstore-frontend/src/app/app.component.html
@@ -77,7 +77,8 @@
       <div class="collapse navbar-collapse" id="navbar-collapse-1">
 
         <ul class="nav navbar-nav">
-          <li [routerLinkActive]="['active']"><a routerLink="/app">Applications</a></li>
+          <li *ngIf="router.url.indexOf('/app') == 0" [routerLinkActive]="['active']"><a routerLink="/app">Applications</a></li>
+          <li *ngIf="router.url === '/'" [routerLinkActive]="['active']"><a routerLink="/">Applications</a></li>
           <ng-container *ngIf="user">
             <li [routerLinkActive]="['active']"><a routerLink="/upload">Upload your RIOT application</a></li>
             <!--<li *ngIf="user && user.is_dev"><a routerLink="developer">Developer</a></li>-->


### PR DESCRIPTION
Reason: with "/" instead of "/app" as root url, pattern matching fails to identify active tab.

This PR is fixing #62 