### PR TITLE
Fix crontab script

### DIFF
--- a/django/crontab
+++ b/django/crontab
@@ -1,5 +1,5 @@
 LANG=en_US.UTF-8
 LC_CTYPE=en_US.UTF-8
 
-* * * * * root /usr/local/bin/python /code/manage.py populate_db 2>&1 >> /var/log/t.log
+0 */3 * * * root /bin/bash -l -c 'SECRET_KEY=cron python /code/manage.py populate_db'
 # An empty line is required at the end of this file for a valid cron file.


### PR DESCRIPTION
This PR adds SECRET_KEY to crontab script. This change is required in order to properly run populate_db from cron jobs.