### PR TITLE
Angular: remove drag'n drop

### DIFF
--- a/rapstore-frontend/src/app/app-build/app-build.component.html
+++ b/rapstore-frontend/src/app/app-build/app-build.component.html
@@ -22,15 +22,6 @@
       <div [hidden]="!loading" class="alert alert-success">
           Successfully requested build. You can continue browsing the website while the service builds the app.
       </div>
-      <div class="well well-sm">
-        <p *ngIf="selected_board?.storage_flash_support">
-          <i class="fa fa-check"></i> This board supports Drag and Drop flashing. <a routerLink="/install-instruction-drag-and-drop">Follow the instructions here.</a>
-        </p>
-
-        <p *ngIf="!selected_board?.storage_flash_support">
-          <i class="fa fa-times"></i> This board doesn't support Drag and Drop. Only ELF file is provided.
-        </p>
-      </div>
       <div class="form-group">
         Board
         <app-board-selector (notify)="onBoardChange($event)"></app-board-selector>
@@ -43,10 +34,10 @@
       -->
       <!--<button type="button" class="btn btn-primary">Install on device</button>-->
       <div class="btn-group" role="group" aria-label="Basic example">
-        <button [hidden]="!selected_board?.storage_flash_support" [disabled]="loading" type="button" class="btn btn-primary download-binary-with-info"
+        <button [disabled]="loading" type="button" class="btn btn-primary download-binary-with-info"
                 (click)="request_build(application.id, 'bin')">Download binary file
         </button>
-        <button [hidden]="!selected_board?.storage_flash_support" [disabled]="loading" routerLink="/install-instruction-drag-and-drop" type="button" class="btn btn-primary" style="margin-right: 0.5em">
+        <button [disabled]="loading" routerLink="/install-instruction-drag-and-drop" type="button" class="btn btn-primary" style="margin-right: 0.5em">
           <i class="fa fa-info"></i>
         </button>
         <button [disabled]="loading" type="button" class="btn btn-primary download-binary-with-info"


### PR DESCRIPTION
This PR removes the Drag'n Drop filter, so all boards can download a BIN or ELF file (regardless if DnD is supported or not).

Besides being easier to maintain (so far), if doesn't exclude boards that might have software-based bootloader with mass storage support