### PR TITLE
Fix the status check for a requested build on the server

### DIFF
--- a/rapstore-frontend/src/app/appservice.service.ts
+++ b/rapstore-frontend/src/app/appservice.service.ts
@@ -57,8 +57,6 @@ export class AppService {
                 const index: number = this.buildQueue.indexOf(task_id);
                 if (index !== -1) {
                   this.buildQueue.splice(index, 1);
-                }
-                else {
                   clearInterval(poll_id);
                 }
               }


### PR DESCRIPTION
The interval that checks the build status on the server was not cleared when the task was done.